### PR TITLE
Use str instead of basestring

### DIFF
--- a/args.py
+++ b/args.py
@@ -34,7 +34,7 @@ def _expand_path(path):
 def _is_collection(obj):
     """Tests if an object is a collection. Strings don't count."""
 
-    if isinstance(obj, basestring):
+    if isinstance(obj, str):
         return False
 
     return hasattr(obj, '__getitem__')


### PR DESCRIPTION
Created a new branch for Python 3, and made the only necessary change to make the module compatible with Python 3

I also used 2to3 to check if there's something else, it didn't find anything.

Disclaimer: I haven't tested anything, I'm assuming everything else works exactly the same.
