### PR TITLE
Basic support for assignments.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ Development Lead
 Patches and Suggestions
 ---
     - Kracekumar <me@kracekumar.com>
+    - Steven Honson
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Here's an example application::
     print 'Files detected: ' + str(args.files)
     print 'NOT files detected: ' + str(args.not_files)
     print 'Grouped Arguments: ' + str(args.grouped)
+    print 'Assignments detected: ' + str(args.assignments)
 
 No arguments::
 
@@ -23,44 +24,49 @@ No arguments::
     Arguments passed in: []
     Flags detected: <args []>
     Files detected: []
-    NOT Files detected: <args []>
-    Grouped Arguments: {'_': <args []>}
+    NOT files detected: <args []>
+    Grouped Arguments: OrderedDict([('_', <args []>)])
+    Assignments detected: OrderedDict()
 
 A few arguments::
 
-    $ tool -s this that --import this and that and this and that
-    Arguments passed in: ['-s', 'this', 'that', '--import', 'this', 'and', 'that', 'and', 'this', 'and', 'that']
-    Flags detected: <args ['-s', '--import'
+    $ tool -s this that --arch=x64 --import this and that and this and that --arch=i386
+    Arguments passed in: ['-s', 'this', 'that', '--arch=x64', '--import', 'this', 'and', 'that', 'and', 'this', 'and', 'that', '--arch=i386']
+    Flags detected: <args ['-s', '--arch=x64', '--import', '--arch=i386']>
     Files detected: []
-    NOT Files detected: <args ['-s', 'this', 'that', '--import', 'this', 'and', 'that', 'and', 'this', 'and', 'that']>
-    Grouped Arguments: {'--import': <args ['this', 'and', 'that', 'and', 'this', 'and', 'that']>, '_': <args []>, '-s': <args ['this', 'that']>}
+    NOT files detected: <args ['-s', 'this', 'that', '--arch=x64', '--import', 'this', 'and', 'that', 'and', 'this', 'and', 'that', '--arch=i386']>
+    Grouped Arguments: OrderedDict([('_', <args []>), ('-s', <args ['this', 'that']>), ('--arch=x64', <args []>), ('--import', <args ['this', 'and', 'that', 'and', 'this', 'and', 'that']>), ('--arch=i386', <args []>)])
+    Assignments detected: OrderedDict([('--arch=', <args ['x64', 'i386']>)])
 
 A few expanded file arguments::
 
     $ tool *.py
-    Arguments passed in: ['args.py', 'setup.py']
+    Arguments passed in: ['args.py', 'setup.py', 'tests.py']
     Flags detected: <args []>
-    Files detected: ['args.py', 'setup.py']
-    NOT Files detected: <args []>
-    Grouped Arguments: {'_': <args ['args.py', 'setup.py']>}
+    Files detected: ['args.py', 'setup.py', 'tests.py']
+    NOT files detected: <args []>
+    Grouped Arguments: OrderedDict([('_', <args ['args.py', 'setup.py', 'tests.py']>)])
+    Assignments detected: OrderedDict()
 
 A few non-expanded file arguments::
 
     $ tool '*.py'
     Arguments passed in: ['*.py']
     Flags detected: <args []>
-    Files detected: ['args.py', 'setup.py']
-    NOT Files detected: <args []>
-    Grouped Arguments: {'_': <args ['*.py']>}
+    Files detected: ['args.py', 'setup.py', 'tests.py']
+    NOT files detected: <args []>
+    Grouped Arguments: OrderedDict([('_', <args ['*.py']>)])
+    Assignments detected: OrderedDict()
 
 A few mixed files/flags/arguments::
 
-    $ tool '*.py' --test test face book -s ~/.ssh
-    Arguments passed in: ['*.py', '--test', 'test', 'face', 'book', '-s', '/Users/kreitz/.ssh']
-    Flags detected: <args ['--test', '-s']>
-    Files detected: ['args.py', 'setup.py', '/Users/kreitz/.ssh/id_rsa', '/Users/kreitz/.ssh/id_rsa.pub', '/Users/kreitz/.ssh/known_hosts']
-    NOT Files detected: <args ['--test', 'test', 'face', 'book', '-s']>
-    Grouped Arguments: {'--test': <args ['test', 'face', 'book']>, '_': <args ['*.py']>, '-s': <args ['/Users/kreitz/.ssh']>}
+    $ tool '*.py' --test test face book -s ~/.ssh --arch=x64
+    Arguments passed in: ['*.py', '--test', 'test', 'face', 'book', '-s', '/home/example/.ssh', '--arch=x64']
+    Flags detected: <args ['--test', '-s', '--arch=x64']>
+    Files detected: ['args.py', 'setup.py', 'tests.py', '/home/example/.ssh/authorized_keys']
+    NOT files detected: <args ['--test', 'test', 'face', 'book', '-s', '--arch=x64']>
+    Grouped Arguments: OrderedDict([('_', <args ['*.py']>), ('--test', <args ['test', 'face', 'book']>), ('-s', <args ['/home/example/.ssh']>), ('--arch=x64', <args []>)])
+    Assignments detected: OrderedDict([('--arch=', <args ['x64']>)])
 
 
 Installation

--- a/args.py
+++ b/args.py
@@ -379,6 +379,19 @@ class ArgsList(object):
 
         return ArgsList(self.all)
 
+    @property
+    def assignments(self):
+        """Extracts assignment values from assignments."""
+
+        collection = OrderedDict()
+
+        for arg in self.all:
+            if '=' in arg:
+                collection.setdefault(arg.split('=', 1)[0], ArgsList(no_argv=True))
+                collection[arg.split('=', 1)[0]]._args.append(arg.split('=', 1)[1])
+
+        return collection
+
 
 args = ArgsList()
 get = args.get
@@ -404,3 +417,4 @@ not_flags = args.not_flags
 files = args.files
 not_files = args.not_files
 copy = args.copy
+assignments = args.assignments

--- a/tests.py
+++ b/tests.py
@@ -52,4 +52,15 @@ def test_start_with():
     arg = args.ArgsList(args = arguments)
     ok_(arg.start_with('p').all == dynamic_lang)
 
+def test_assignments():
+    details = {'--arch': ['x64', 'i386'], 'lang': ['']}
+    arguments = []
+    for key in details:
+        for argument in details[key]:
+            arguments.append(key + '=' + argument)
+
+    arg = args.ArgsList(args = arguments)
+    for item in arg.assignments:
+        ok_(arg.assignments[item].all == details[item])
+
 


### PR DESCRIPTION
I noticed that issue #2 is to add support for assignments, so I decided to have a go at adding basic support.

A few notes on the implementation,
- Assignments in a variety of formats are supported.
- Supports multiple values for one assignment as well as empty/blank values.
- Effectively any attribute containing an equals sign is treated as an assignment.

The following are examples of some of the supported formats for the assignment argument.

```
--multivalueargument=value1 --multivalueargument=value2 --emptyvalue= -anotherformat=value3 yetanotherformat=value4
```

The resulting output for the above being,

```
OrderedDict([('--multivalueargument', <args ['value1', 'value2']>), ('--emptyvalue', <args ['']>), ('-anotherformat', <args ['value3']>), ('yetanotherformat', <args ['value4']>)])
```
