### PR TITLE
Added tox testing.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Patches and Suggestions
 -----------------------
 - Kracekumar <me@kracekumar.com>
 - Steven Honson
+- Justin Barber <barber.justin (at) gmail>

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27, py32
+
+[testenv]
+commands=py.test tests.py
+deps = nose
+    pytest


### PR DESCRIPTION
OrderedDict not introduced till after 2.6. Only including 2.7 and
greater in tox.
